### PR TITLE
Variables should not be self-assigned

### DIFF
--- a/main.go
+++ b/main.go
@@ -17,3 +17,7 @@ func main() {
 	listenAddress := "192.168.0.101:8080"
 	log.Fatal(http.ListenAndServe(listenAddress, nil)) // Start the server
 }
+
+func rename(name string) {
+  name = name  // Noncompliant
+}


### PR DESCRIPTION
Adapted from https://rules.sonarsource.com/go/type/Bug/RSPEC-1656/.